### PR TITLE
Add jpeg file output quality setting parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Flags:
   -l, --len int      edge length of a cube face (default 1024)
   -o, --out string   out file dir path (default ".")
   -s, --sides array  list of sides splited by "," (optional)
+  -q, --quality int  jpeg file output quality ranges from 1 to 100 inclusive, higher is better (optional, default 75)
 ```
 
 ``` sh
 # example
-./panorama --in ./sample_image.jpg --out ./dist --len 512 --sides left,right,top,buttom,front,back
+./panorama --in ./sample_image.jpg --out ./dist --len 512 --sides left,right,top,bottom,front,back
 ```
 
 ### Installation

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 const (
 	defaultEdgeLen     = 1024
 	maxConcurrentFiles = 10 // Adjust this number based on your system's file descriptor limit
+	defaultJpegQuality = 75
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 	inDirPath  string
 	edgeLen    int
 	sides      []string
+	quality    int
 
 	validSides = []string{"front", "back", "left", "right", "top", "bottom"}
 	semaphore  = make(chan struct{}, maxConcurrentFiles)
@@ -75,6 +77,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&outFileDir, "out", "o", ".", "output file directory path")
 	rootCmd.Flags().IntVarP(&edgeLen, "len", "l", defaultEdgeLen, "edge length of a cube face")
 	rootCmd.Flags().StringSliceVarP(&sides, "sides", "s", []string{}, "array of sides [front,back,left,right,top,bottom] (default: all sides)")
+	rootCmd.Flags().IntVarP(&quality, "quality", "q", defaultJpegQuality, "jpeg file output quality ranges from 1 to 100 inclusive, higher is better")
 }
 
 func processSingleImage(inPath, outDir string, needSubdir bool) {
@@ -111,7 +114,7 @@ func processSingleImage(inPath, outDir string, needSubdir bool) {
 	if needSubdir {
 		outDir = filepath.Join(outDir, strings.TrimSuffix(filepath.Base(inPath), filepath.Ext(inPath)))
 	}
-	if err := conv.WriteImage(canvases, outDir, ext, sides); err != nil {
+	if err := conv.WriteImage(canvases, outDir, ext, sides, quality); err != nil {
 		progress.Lock()
 		progress.errors = append(progress.errors, fmt.Sprintf("Error writing images for %s: %v", inPath, err))
 		progress.Unlock()

--- a/conv/img.go
+++ b/conv/img.go
@@ -53,7 +53,7 @@ func ReadImage(imagePath string) (image.Image, string, error) {
 	return nil, "", errors.New("unsupported image format: " + ext)
 }
 
-func WriteImage(canvases []*image.RGBA, writeDirPath, imgExt string, sides []string) error {
+func WriteImage(canvases []*image.RGBA, writeDirPath, imgExt string, sides []string, quality int) error {
 	if len(canvases) != len(sides) {
 		return errors.New("mismatched face size and sides length")
 	}
@@ -76,7 +76,8 @@ func WriteImage(canvases []*image.RGBA, writeDirPath, imgExt string, sides []str
 
 		switch imgExt {
 		case "jpeg":
-			if err := jpeg.Encode(newFile, canvases[i], nil); err != nil {
+			opt := jpeg.Options{Quality: quality}
+			if err := jpeg.Encode(newFile, canvases[i], &opt); err != nil {
 				return err
 			}
 		case "png":


### PR DESCRIPTION
This pull request introduces the following changes:

- **JPEG Output Quality Parameter:**  
  A new parameter has been added to allow users to set the output quality of JPEG files. This enhancement provides greater flexibility and control over the image quality during processing.
  e.g. `./panorama --in ./sample_image.jpg --out ./dist --len 512 --sides left,right,top,bottom,front,back --quality 100`

- **README Typos Fixed:**  
  Corrected several typographical errors in the README file to improve clarity and professionalism.
